### PR TITLE
fix: storybook for svg

### DIFF
--- a/libs/svg-layout/.storybook/webpack.config.js
+++ b/libs/svg-layout/.storybook/webpack.config.js
@@ -1,18 +1,20 @@
-const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+// const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
-// Export a function. Accept the base config as the only param.
-module.exports = async ({ config }) => {
-	config.resolve.extensions.push('.svg');
+// // Export a function. Accept the base config as the only param.
+// module.exports = async ({ config }) => {
+//   config.resolve.extensions.push('.svg');
 
-	config.module.rules = config.module.rules.map((data) => {
-		if (/svg\|/.test(String(data.test))) data.test = /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani)(\?.*)?$/;
-		return data;
-	});
+//   config.module.rules = config.module.rules.map((data) => {
+//     if (/svg\|/.test(String(data.test)))
+//       data.test =
+//         /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani)(\?.*)?$/;
+//     return data;
+//   });
 
-	config.module.rules.push({
-		test: /\.svg$/,
-		use: [{ loader: 'svg-inline-loader' }]
-	});
+//   // config.module.rules.push({
+//   // 	test: /\.svg$/,
+//   // 	use: [{ loader: 'svg-inline-loader' }]
+//   // });
 
-	return config;
-};
+//   return config;
+// };

--- a/libs/svg-layout/src/lib/svg-layout/svg-layout.component.html
+++ b/libs/svg-layout/src/lib/svg-layout/svg-layout.component.html
@@ -1,11 +1,22 @@
-<svg [attr.viewBox]="viewbox.minx + ' ' + viewbox.miny + ' ' + viewbox.width + ' ' + viewbox.height">
-    <svg:g
-        workspace-svg-part
-        [sizeLogoRatio]="svgLogoRatio"
-        [fillValueB]="svgFillValueB"
-        [sPoint]="svgSPoint"
-        [tPoint]="svgTPoint"
-        [uPoint]="svgUPoint"
-        [vPoint]="svgVPoint"
-    />
+<svg
+  [attr.viewBox]="
+    viewbox.minx +
+    ' ' +
+    viewbox.miny +
+    ' ' +
+    viewbox.width +
+    ' ' +
+    viewbox.height
+  "
+>
+  <svg:g
+    workspace-svg-part
+    [sizeLogoRatio]="svgLogoRatio"
+    [fillValueB]="svgFillValueB"
+    [sPoint]="svgSPoint"
+    [tPoint]="svgTPoint"
+    [uPoint]="svgUPoint"
+    [vPoint]="svgVPoint"
+  />
+  <text x="10" y="10">My</text>
 </svg>


### PR DESCRIPTION
Issue was coming from your custom `webpack.config.js`.

If you remove that, Storybook builds and serves correctly.

I added a `<text>` tag to your `svg-layout.component.html` so that you can see that storybook is correctly rendering the SVG.



That said. Storybook is not correctly handling the `.svg` file as a templateUrl. 

There's an open issue on the Storybook Repo about this:
https://github.com/storybookjs/storybook/issues/16438 